### PR TITLE
Add JSON result as fallback, refactor template and set error status

### DIFF
--- a/src/query/query.router.ts
+++ b/src/query/query.router.ts
@@ -11,7 +11,7 @@ queryRouter.get('/:type/:host/:port', async (req: Request, res: Response) => {
         const port: number = parseInt(req.params.port);
         const outputTemplate: string = decodeURI(req.query.template as string);
         let offlineMessage: string = decodeURI(req.query.offline_message as string);
-        if(!offlineMessage) {
+        if(!req.query.offline_message) {
             offlineMessage = 'Server offline';
         }
 
@@ -40,7 +40,7 @@ queryRouter.get('/:type/:host/:port', async (req: Request, res: Response) => {
 	      res.status(200).json(r);
 	    }
         }).catch(e => {
-            res.status(200).send(offlineMessage);
+            res.status(500).send(offlineMessage);
         });
     } catch (e) {
         res.status(404).send(e.message);

--- a/src/query/query.router.ts
+++ b/src/query/query.router.ts
@@ -26,15 +26,19 @@ queryRouter.get('/:type/:host/:port', async (req: Request, res: Response) => {
                 server_ping = r.ping,
                 server_connect = r.connect;
 
-            let renderLine = outputTemplate;
-            renderLine = renderLine.replace('{type}', type.toString());
-            renderLine = renderLine.replace('{host}', host);
-            renderLine = renderLine.replace('{port}', port.toString());
-            renderLine = renderLine.replace('{players_amount}', players_amount.toString());
-            renderLine = renderLine.replace('{players_max}', players_max.toString());
-            renderLine = renderLine.replace('{server_ping}', server_ping.toString());
-            renderLine = renderLine.replace('{server_connect}', server_connect);
-            res.status(200).send(renderLine);
+	    if (req.query.template) {
+	      const renderLine = outputTemplate
+                    .replace(/{type}/g, type.toString())
+                    .replace(/{host}/g, host)
+                    .replace(/{port}/g, port.toString())
+                    .replace(/{players_amount}/g, players_amount.toString())
+                    .replace(/{players_max}/g, players_max.toString())
+                    .replace(/{server_ping}/g, server_ping.toString())
+                    .replace(/{server_connect}/g, server_connect);
+	      res.status(200).send(renderLine);
+	    } else {
+	      res.status(200).json(r);
+	    }
         }).catch(e => {
             res.status(200).send(offlineMessage);
         });


### PR DESCRIPTION
Hello, 

First of all, thank you for your work, I needed a dockerized gamedig instance and your project is perfect :) However, I needed a JSON result and your templating system was great but not what I needed, moreover when you don't set the template query in the API URL, your API returns `undefined`. I fixed it by sending the JSON result instead. If you set the template query, it will work as it used to.

I also refactored the template building with regex and const to fix allow template with the same keyword multiple times.

Finally, I set the response status to 500 if gamedig throws an error.

Feel free to review this PR and to give me your opinion of this patch.

Have a nice day :)